### PR TITLE
Fix typo in data_containers.h

### DIFF
--- a/libs/data_containers.h
+++ b/libs/data_containers.h
@@ -226,7 +226,7 @@ public:
   int detectorNum;
   /* we will alow as many detector 
 			   definitions as the user wants */
-  std::vector<std::vector<DETECTOR>> detectors;
+  std::vector<std::vector<DETECTOR> > detectors;
   //DETECTOR *detectors;
   int save_output_flag;
   


### PR DESCRIPTION
Compiler complained:
./QSTEM/libs/data_containers.h:229:35: error: ‘>>’ should be ‘> >’ within a nested template argument list
