### PR TITLE
Natural sorting of file list in showimage.m

### DIFF
--- a/GUI_Matlab/showimage.m
+++ b/GUI_Matlab/showimage.m
@@ -148,7 +148,9 @@ end
 % handles.directoryname
 handles.files = dir(sprintf('%s\\*.img',handles.directoryname));
 % handles.files.name
-set(handles.listbox_image,'String',{handles.files.name});
+% To view in workspace: assignin('base','names',sort_nat({handles.files.name}))
+% sort_nat does a natural sort, so images appear in order
+set(handles.listbox_image,'String',sort_nat({handles.files.name}));
 set(handles.listbox_image,'Value',1);
 handles = listbox_image_Callback(hObject, eventdata, handles,0,filename);
 guidata(hObject, handles);

--- a/GUI_Matlab/sort_nat.m
+++ b/GUI_Matlab/sort_nat.m
@@ -1,0 +1,95 @@
+function [cs,index] = sort_nat(c,mode)
+%sort_nat: Natural order sort of cell array of strings.
+% usage:  [S,INDEX] = sort_nat(C)
+%
+% where,
+%    C is a cell array (vector) of strings to be sorted.
+%    S is C, sorted in natural order.
+%    INDEX is the sort order such that S = C(INDEX);
+%
+% Natural order sorting sorts strings containing digits in a way such that
+% the numerical value of the digits is taken into account.  It is
+% especially useful for sorting file names containing index numbers with
+% different numbers of digits.  Often, people will use leading zeros to get
+% the right sort order, but with this function you don't have to do that.
+% For example, if C = {'file1.txt','file2.txt','file10.txt'}, a normal sort
+% will give you
+%
+%       {'file1.txt'  'file10.txt'  'file2.txt'}
+%
+% whereas, sort_nat will give you
+%
+%       {'file1.txt'  'file2.txt'  'file10.txt'}
+%
+% See also: sort
+
+% Version: 1.4, 22 January 2011
+% Author:  Douglas M. Schwarz
+% Email:   dmschwarz=ieee*org, dmschwarz=urgrad*rochester*edu
+% Real_email = regexprep(Email,{'=','*'},{'@','.'})
+
+
+% Set default value for mode if necessary.
+if nargin < 2
+	mode = 'ascend';
+end
+
+% Make sure mode is either 'ascend' or 'descend'.
+modes = strcmpi(mode,{'ascend','descend'});
+is_descend = modes(2);
+if ~any(modes)
+	error('sort_nat:sortDirection',...
+		'sorting direction must be ''ascend'' or ''descend''.')
+end
+
+% Replace runs of digits with '0'.
+c2 = regexprep(c,'\d+','0');
+
+% Compute char version of c2 and locations of zeros.
+s1 = char(c2);
+z = s1 == '0';
+
+% Extract the runs of digits and their start and end indices.
+[digruns,first,last] = regexp(c,'\d+','match','start','end');
+
+% Create matrix of numerical values of runs of digits and a matrix of the
+% number of digits in each run.
+num_str = length(c);
+max_len = size(s1,2);
+num_val = NaN(num_str,max_len);
+num_dig = NaN(num_str,max_len);
+for i = 1:num_str
+	num_val(i,z(i,:)) = sscanf(sprintf('%s ',digruns{i}{:}),'%f');
+	num_dig(i,z(i,:)) = last{i} - first{i} + 1;
+end
+
+% Find columns that have at least one non-NaN.  Make sure activecols is a
+% 1-by-n vector even if n = 0.
+activecols = reshape(find(~all(isnan(num_val))),1,[]);
+n = length(activecols);
+
+% Compute which columns in the composite matrix get the numbers.
+numcols = activecols + (1:2:2*n);
+
+% Compute which columns in the composite matrix get the number of digits.
+ndigcols = numcols + 1;
+
+% Compute which columns in the composite matrix get chars.
+charcols = true(1,max_len + 2*n);
+charcols(numcols) = false;
+charcols(ndigcols) = false;
+
+% Create and fill composite matrix, comp.
+comp = zeros(num_str,max_len + 2*n);
+comp(:,charcols) = double(s1);
+comp(:,numcols) = num_val(:,activecols);
+comp(:,ndigcols) = num_dig(:,activecols);
+
+% Sort rows of composite matrix and use index to sort c in ascending or
+% descending order, depending on mode.
+[unused,index] = sortrows(comp);
+if is_descend
+	index = index(end:-1:1);
+end
+index = reshape(index,size(c));
+cs = c(index);

--- a/GUI_Matlab/sort_nat_license.txt
+++ b/GUI_Matlab/sort_nat_license.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2008, Douglas M. Schwarz
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the distribution
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Added Douglas Schwarz's sort_nat code to perform natural sorting of string cell arrays. This is used to sort the file list that is loaded in showimage.m in order to provide a more intuitive image browsing experience. Tested out with a few folders locally, and seems to work fine. Particularly useful on the output of FRWR3.
