### PR TITLE
Improvements to readCFG.m and writeCFG.m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,12 @@ BuildLog.htm
 *.log
 *.lastbuildstate
 *.cache
+*.sdf
+*.opensdf
 
 # binaries
 /bin
+/test_bin
 
 # build-generated CMake garbage
 /CMakeFiles
@@ -55,3 +58,4 @@ CMakeCache.txt
 # but include the ones from any testing directory
 #    these are for the unit tests.
 !/tests/data/*.img
+*.asv

--- a/GUI_Matlab/drawCFG.m
+++ b/GUI_Matlab/drawCFG.m
@@ -16,7 +16,7 @@ if nargin < 2
 end
 
 % Read the CFG file:
-[coords, aType, Mm] = readCFG(fileName,[0 0 0],2);
+[coords, aType, Mm, ~, ~, ~] = readCFG(fileName);
 
 % extract number of atoms:
 Natom = size(coords,1);

--- a/GUI_Matlab/readCFG.m
+++ b/GUI_Matlab/readCFG.m
@@ -1,7 +1,8 @@
-function [coord,aType,Mm] = readCFG( filename )
+function [coord, aType, Mm, DW, occ, charge] = readCFG( filename )
 
     % Robert A. McLeod
     % 14 April 2014
+    % Last updated: 19 November 2014 by Joshua A. Taillon
     % This is designed to replace readCFG_qstem, which likes to break.
 
     %% Open file
@@ -38,12 +39,26 @@ function [coord,aType,Mm] = readCFG( filename )
     end
 
     fgetl( fHand ); % No velocity
-    fgetl( fHand ); % Nummber of atom types (wrong, do not use)
-
+    buffer = fgetl( fHand ); % entry_count (tells us what factors to use)
+    entries = str2double( buffer( regexp( buffer, '\d' ) ) );
+    
     %% End of .CFG header, start of body
-    % Preallocate
+    % Preallocate arrays based on number of entries
     coord = zeros( [nAtom 3] );
     aType = zeros( [nAtom 1] );
+    charge = [];
+    occ = [];
+    DW = [];
+    if ( entries > 5)
+        charge = zeros( [nAtom 1] );
+        occ = zeros( [nAtom 1] );
+        DW = zeros( [nAtom 1] );
+    elseif (entries > 4)
+        occ = zeros( [nAtom 1] );
+        DW = zeros( [nAtom 1] );
+    elseif (entries > 3)
+        DW = zeros( [nAtom 1] );
+    end
 
     % Try to scan a single number (Z*2) followed by a end-of-line, followed
     % by a character
@@ -56,8 +71,9 @@ function [coord,aType,Mm] = readCFG( filename )
     fgetl( fHand ); % next line, string, discard
     atomIndex = 1;
     while( atomIndex <= nAtom )
-        coordScan = textscan( fHand, '%f%f%f\n', 'CollectOutput', 1 ); % Scan until it hits the next non-match (i.e. a new atom)
+        coordScan = textscan( fHand, '%f%f%f%f%f%f', 'CollectOutput', 1 ); % Scan until it hits the next non-match (i.e. a new atom)
         coordScan = coordScan{1};
+        coordScan = coordScan(:, 1:entries);
         numNewAtoms = size( coordScan,1 );
 
         if( numNewAtoms <= 0 )
@@ -67,23 +83,33 @@ function [coord,aType,Mm] = readCFG( filename )
         if( isnan( coordScan(end,2) ) )
             % Hit a new atom type
             numNewAtoms = numNewAtoms - 1;
-            disp( [ '1: Found ', num2str(numNewAtoms), ' of atomic number Z = ', num2str(atomZ) ] )
+%             disp( [ '1: Found ', num2str(numNewAtoms), ' of atomic number Z = ', num2str(atomZ) ] )
 
             nextAtomZ = coordScan( end, 1 )/2;
             coordScan = coordScan(1:end-1,:);
+            
 
             fgetl( fHand ); % next line, string, discard
         else
-            disp( [ '2: Found ', num2str(numNewAtoms), ' atoms of atomic number Z = ', num2str(atomZ) ] )
+%             disp( [ '2: Found ', num2str(numNewAtoms), ' atoms of atomic number Z = ', num2str(atomZ) ] )
         end
 
         % Add to list
         aType(atomIndex:atomIndex+numNewAtoms-1) = atomZ;
-        coord(atomIndex:atomIndex+numNewAtoms-1,:) = coordScan;
+        coord(atomIndex:atomIndex+numNewAtoms-1,:) = coordScan(:,1:3);
+        if (entries > 3)
+            DW(atomIndex:atomIndex+numNewAtoms-1) = coordScan(:,4);
+        end
+        if (entries > 4)
+            occ(atomIndex:atomIndex+numNewAtoms-1) = coordScan(:,5);
+        end
+        if (entries > 5)
+            charge(atomIndex:atomIndex+numNewAtoms-1) = coordScan(:,6);
+        end
         atomIndex = atomIndex + numNewAtoms;
 
         atomZ = nextAtomZ;
     end
-
+    disp(['Read in ' num2str(nAtom) ' atoms from ' filename_ext '.'])
     fclose( fHand );
 end

--- a/GUI_Matlab/writeCFG.m
+++ b/GUI_Matlab/writeCFG.m
@@ -1,4 +1,4 @@
-% function writeCFG(fileName,Mm,aType,coords,shift,mode,DW,charge)
+% function writeCFG(fileName,Mm,aType,coords,shift,mode,DW,occ,charge)
 %
 % fileName:   name of cfg file
 % Mm:         metric matrix (for orthogonal unit cells or super structures
@@ -13,8 +13,9 @@
 %             1 = atom positions in coords are cartesian coordinates
 % DW:         Debye-Waller factor: this can be a single number or a vector
 %             with a separate value for each atom
+% occ:        vector with value of occupancy for each
 % charge:     vector with value of charge per atom
-function success = writeCFG(fileName,Mm,aType,coords,shift,mode,DW,charge)
+function success = writeCFG(fileName,Mm,aType,coords,shift,mode,DW,occ,charge)
 
 if nargin < 5
     shift = [0 0 0];
@@ -44,17 +45,20 @@ fprintf(fid,'Number of particles = %d\n',N);
 fprintf(fid,'A = 1.0 Angstrom (basic length-scale)\n');
 for ix=1:3
     for iy=1:3
-        fprintf(fid,'H0(%d,%d) = %g A\n',ix,iy,Mm(ix,iy));
+        fprintf(fid,'H0(%d,%d) = %10.3f A\n',ix,iy,Mm(iy,ix));
     end
 end
 fprintf(fid,'.NO_VELOCITY.\n');
-if nargin < 8
+if nargin < 7               % 6 or fewer arguments means no DW, occ, or charge
     fprintf(fid,'entry_count = 3\n');
 end
-if nargin == 8
+if nargin == 7              % 7 args means just DW included
+    fprintf(fid,'entry_count = 4\n');
+end
+if nargin == 8              % 8 args means DW and occ included
     fprintf(fid,'entry_count = 5\n');
 end
-if nargin > 8
+if nargin > 8               % 9 args means DW, occ, and charge all included
     fprintf(fid,'entry_count = 6\n');
 end
 
@@ -65,19 +69,22 @@ for ix=1:N
         atomType = at;
     end
     if mode == 1
-        fprintf(fid,'%.5f %.5f %.5f',mod((coords(ix,:)+shift)*Mminv,1));
+        fprintf(fid,'%.6f %.6f %.6f',mod((coords(ix,:)+shift)*Mminv,1));
     else
-        fprintf(fid,'%.5f %.5f %.5f',coords(ix,:));        
+        fprintf(fid,'%.6f %.6f %.6f',coords(ix,:));        
     end    
-    if nargin > 7
+    if nargin > 6           % nargs is at least 7, so write DW
         if length(DW) > 1
-            fprintf(fid,' %.2f 1',DW(ix));
+            fprintf(fid,' %.4f',DW(ix));
         else
-            fprintf(fid,' %.2f 1',DW);            
+            fprintf(fid,' %.4f',DW);            
         end
     end
-    if nargin > 8
-        fprintf(fid,' %.2f',charge(ix));                
+    if nargin > 7           % nargs is at least 8, so write occ, as well
+        fprintf(fid,' %.4f',occ(ix));
+    end
+    if nargin > 8           % nargs is at least 9, so write charge, too
+        fprintf(fid,' %.4f',charge(ix));                
     end
     fprintf(fid,'\n');
 end


### PR DESCRIPTION
- Fixed readCFG.m to correctly read CFG files. Now reads whole line (including DW factors, occ., and charge)
- Fixed writeCFG.m, which was writing the unit vectors in the wrong orientation (relative to readCFG.m). It now writes a file identical to what is read in with readCFG (in my testing)
  - this was causing unit vectors to be transposed, when reading a .cfg in with readCFG.m and then trying to write it with writeCFG.m
  - writeCFG also now explicitly writes the occupancy and everything, which allows it to write a full .cfg file. 
    - This may need to be changed in other places throughout the code, as it appears there are a number of places where writeCFG is embedded inside other scripts.
- Fixed the call to readCFG inside of drawCFG, which caused it not to work.
- Updated .gitignore to ignore Matlab Editor autosave files
