### PR TITLE
Fix calculation of basis vectors in convert2cfg.m

### DIFF
--- a/GUI_Matlab/convert2cfg.m
+++ b/GUI_Matlab/convert2cfg.m
@@ -123,12 +123,16 @@ if (strcmp(ext,'.xtl') == 1)
 
     buf = fgets(fid);
     unitCell = sscanf(buf,'%f',6);
-    a     = unitCell(1);
-    b     = unitCell(2);
-    c     = unitCell(3);
-    alpha = unitCell(4)*pi/180;
-    beta  = unitCell(5)*pi/180;
-    gamma = unitCell(6)*pi/180;
+    a      = unitCell(1);
+    b      = unitCell(2);
+    c      = unitCell(3);
+    alpha  = unitCell(4); 
+    beta   = unitCell(5);  % in degrees
+    gamma  = unitCell(6);  % in degrees
+    alphar = alpha*pi/180; % in radians
+    betar  = beta*pi/180;  % in radians
+    gammar = gamma*pi/180; % in radians
+    
     fprintf('Found unit cell parameters: \na=%f, b=%f, c=%f, \nalpha=%f, beta=%f, gamma=%f\n',a,b,c,alpha,beta,gamma);
 
     % Now look for the atomic positions:
@@ -154,19 +158,19 @@ if (strcmp(ext,'.xtl') == 1)
     H00 = a;
     H01 = 0;
     H02 = 0;
-    H10 = b*cos(gamma);
-    H11 = b*sin(gamma);
+    H10 = b*cosd(gamma);    % do these calcs in degrees to avoid rounding errors
+    H11 = b*sind(gamma);    % do these calcs in degrees to avoid rounding errors
     H12 = 0;
     H20 = 0;
     H21 = 0;
     H22 = c;
     Mm = [H00 H01 H02;H10 H11 H12; H20 H21 H22];
-
+    
     % start a refinement to search for the correct matrix entries in the 3rd
     % row:
-    if (abs(alpha-pi/2) > 1e-4) ||  (abs(beta-pi/2) > 1e-4)
+    if (abs(alphar-pi/2) > 1e-4) ||  (abs(betar-pi/2) > 1e-4)
         H3 = Mm(3,:).';
-        [H3,chi2] = fminsearch(@(H3) refineMatrix(H3,Mm,alpha*180/pi,beta*180/pi,gamma*180/pi), H3);
+        [H3,chi2] = fminsearch(@(H3) refineMatrix(H3,Mm,alphar*180/pi,betar*180/pi,gammar*180/pi), H3);
         fprintf('found structure matrix with chi2 = %f\n',chi2);
         Mm(3,:) = H3.'*c/sqrt(sum(H3.^2));
         Mm(3,3) = abs(Mm(3,3));
@@ -364,9 +368,9 @@ end
 fclose(fid);
 
 
-function chi2 = refineMatrix(H3,H,alpha,beta,gamma)
+function chi2 = refineMatrix(H3,H,alphar,betar,gammar)
 H(3,:) = H3.';
-alphaP = acos(sum(H(2,:).*H(3,:))/sqrt(sum(H(2,:).^2)*sum(H(3,:).^2)))*180/pi;
-betaP =  acos(sum(H(1,:).*H(3,:))/sqrt(sum(H(1,:).^2)*sum(H(3,:).^2)))*180/pi;
-% fprintf('Angles of matrix: alpha = %.2f°, beta = %.2f°, gamma = %.2f°\n',alphaP,betaP,gammaP);
-chi2 = 100000*(alphaP-alpha)^2+(betaP-beta)^2;
+alpharP = acos(sum(H(2,:).*H(3,:))/sqrt(sum(H(2,:).^2)*sum(H(3,:).^2)))*180/pi;
+betarP =  acos(sum(H(1,:).*H(3,:))/sqrt(sum(H(1,:).^2)*sum(H(3,:).^2)))*180/pi;
+fprintf('Angles of matrix: alphar = %.2f°, betar = %.2f°, gammar = %.2f°\n',alpharP,betarP,gammarP);
+chi2 = 100000*(alpharP-alphar)^2+(betarP-betar)^2;


### PR DESCRIPTION
- Changed convert2cfg.m to do it's basis vector calculations in degrees Kept all other calculations involving alpha, beta, and gamma in radians (for now) by refactoring the variables to alphar, betar, and gammar, respectively.
  - This prevents very small values arising from (I think) floating point rounding errors in the degree -> radian conversion
  - My initial tests show that it's writing the CFG file correctly now (testing with the BaTiO3 cell and my own 4H-SiC and a-SiO2 data)
- This is the email I sent describing this change:
  - I found that the cos(gamma) call on line 157 of convert2cfg.m was causing very small rounding errors resulting in a very small value for H0(2,1) (something like 2.6e-16). This would be fine, but it looks like QSTEM has trouble reading this in. It's not too much trouble to manually change this to 0 within the .cfg file afterwards, but by switching those two calculations to degrees, I think we can avoid the rounding errors. I've included those changes in a new pull request on github.
